### PR TITLE
also flag arrays of objects as red..

### DIFF
--- a/src/app/main/main.controller.js
+++ b/src/app/main/main.controller.js
@@ -19,11 +19,14 @@
 
     function extractNode(schema, parentId, name) {
       var retStr = '    ' + objectId(schema) + ' [label="' + name + '"];';
-    
+
       if (schema.type == 'object') {
         retStr += '    ' + objectId(schema) + ' [shape=box];';
       }
-      if (schema.type == 'object' && !schema.properties) {
+      if (
+          (schema.type == 'object' && !schema.properties) ||
+          (schema.type == 'array' && schema.items.type == 'object' && !schema.properties)
+      ) {
         retStr += '    ' + objectId(schema) + ' [style=filled, fillcolor=red];';
       }
 


### PR DESCRIPTION
i defined a field as type `object` and named it `checklists.0`, leading to an array of unstructured objects.. this wasn't marked as red in visualizer, this tried to fix that as IMHO they should be red as well..